### PR TITLE
fix(loki): when cloning, metadata will be applied correctly and clones emitted

### DIFF
--- a/packages/common/types.ts
+++ b/packages/common/types.ts
@@ -16,7 +16,8 @@ export interface StorageAdapter {
 }
 
 export type Doc<T extends object = object> = T & {
-  $loki: number; meta?: {
+  $loki: number;
+  meta?: {
     created: number;
     revision: number;
     version: number,

--- a/packages/loki/spec/generic/changesApi.spec.ts
+++ b/packages/loki/spec/generic/changesApi.spec.ts
@@ -9,8 +9,6 @@ describe("changesApi", () => {
 
   it("does what it says on the tin", () => {
     const db = new Loki();
-    // gordian = require('gordian'),
-    // suite = new gordian('testEvents'),
     const options = {
       asyncListeners: false,
       disableChangesApi: false
@@ -61,7 +59,7 @@ describe("changesApi", () => {
     expect(users.getChanges().length).toEqual(0);
   });
 
-  it("works with delta mode", function () {
+  it("works with delta mode", () => {
     const db = new Loki();
     const options = {
       asyncListeners: false,
@@ -107,5 +105,67 @@ describe("changesApi", () => {
     expect(secondUpdate.operation).toEqual("U");
     expect(secondUpdate.obj.owner).toBeUndefined();
     expect(secondUpdate.obj.maker).toEqual({count: 4});
+  });
+
+  it("batch operations work with delta mode", () => {
+
+    interface User {
+      name: string;
+      maker: string;
+      owner: string;
+      count: number;
+    }
+
+    const db = new Loki();
+    const options = {
+      asyncListeners: false,
+      disableChangesApi: false,
+      disableDeltaChangesApi: false
+    };
+    const items = db.addCollection<User>("items", options);
+
+    // Add some documents to the collection
+    items.insert([
+      {name: "mjolnir", owner: "thor", maker: "dwarves", count: 0},
+      {name: "gungnir", owner: "odin", maker: "elves", count: 0},
+      {name: "tyrfing", owner: "Svafrlami", maker: "dwarves", count: 0},
+      {name: "draupnir", owner: "odin", maker: "elves", count: 0}
+    ]);
+
+    items.chain().update((o) => {
+      o.count++;
+      return o;
+    });
+
+    const changes = JSON.parse(db.serializeChanges(["items"]));
+    expect(changes.length).toEqual(8);
+
+    expect(changes[0].name).toEqual("items");
+    expect(changes[0].operation).toEqual("I");
+    expect(changes[1].name).toEqual("items");
+    expect(changes[1].operation).toEqual("I");
+    expect(changes[2].name).toEqual("items");
+    expect(changes[2].operation).toEqual("I");
+    expect(changes[3].name).toEqual("items");
+    expect(changes[3].operation).toEqual("I");
+
+    expect(changes[4].name).toEqual("items");
+    expect(changes[4].operation).toEqual("U");
+    expect(changes[4].obj.count).toEqual(1);
+    expect(changes[5].name).toEqual("items");
+    expect(changes[5].operation).toEqual("U");
+    expect(changes[5].obj.count).toEqual(1);
+    expect(changes[6].name).toEqual("items");
+    expect(changes[6].operation).toEqual("U");
+    expect(changes[6].obj.count).toEqual(1);
+    expect(changes[7].name).toEqual("items");
+    expect(changes[7].operation).toEqual("U");
+    expect(changes[7].obj.count).toEqual(1);
+
+    const keys = Object.keys(changes[7].obj);
+    keys.sort();
+    expect(keys[0]).toEqual("$loki");
+    expect(keys[1]).toEqual("count");
+    expect(keys[2]).toEqual("meta");
   });
 });


### PR DESCRIPTION
Decoupled metadata functionality from emitted 'insert' and 'update' events so that we can apply metadata and changes with internal object references, while emitting to user a clone of the internal object.

See techfort/LokiJS/#666

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/LokiJS-Forge/LokiDB/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
