### PR TITLE
fix(loki): getENV isNode test depend on global are easy to modified b…

### DIFF
--- a/packages/loki/src/loki.ts
+++ b/packages/loki/src/loki.ts
@@ -11,7 +11,7 @@ function getENV(): Loki.Environment {
     return "NATIVESCRIPT";
   }
 
-  const isNode = global !== undefined && ({}).toString.call(global) === "[object global]";
+  const isNode = global !== undefined && ({}).toString.call(global.process) === "[object process]";
   if (isNode) {
     if (global["window"]) {
       return "NODEJS"; //node-webkit


### PR DESCRIPTION
fix(loki): getENV isNode test depend on global are easy to modified by external register such as ts-node and jest.
use global.process instead.


## PR Checklist
Please check if your PR fulfills the following requirements:

- [X ] The commit message follows our guidelines: https://github.com/LokiJS-Forge/LokiDB/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
