### PR TITLE
Allow a Storage implementation to be passed into the LocalStorage adapter

### DIFF
--- a/packages/local-storage/spec/fixtures/in-memory-local-storage.ts
+++ b/packages/local-storage/spec/fixtures/in-memory-local-storage.ts
@@ -1,0 +1,45 @@
+export class InMemoryLocalStorage implements Storage {
+  private data: Record<string, string> = {};
+
+  length: number;
+  clear(): void {
+    this.data = {};
+  }
+  getItem(key: string): string | null {
+    return this.data[key];
+  }
+  key(index: number): string | null {
+    return Object.keys(this.data)[index] || null;
+  }
+  removeItem(key: string): void {
+    if (key in this.data) {
+      delete this.data[key];
+    }
+  }
+  setItem(key: string, value: string): void {
+    this.data[key] = value;
+  }
+}
+
+export class AsyncInMemoryLocalStorage {
+  private data: Record<string, string> = {};
+
+  length: number;
+  async clear(): Promise<void> {
+    this.data = {};
+  }
+  async getItem(key: string): Promise<string | null> {
+    return this.data[key];
+  }
+  async key(index: number): Promise<string | null> {
+    return Object.keys(this.data)[index] || null;
+  }
+  async removeItem(key: string): Promise<void> {
+    if (key in this.data) {
+      delete this.data[key];
+    }
+  }
+  async setItem(key: string, value: string): Promise<void> {
+    this.data[key] = value;
+  }
+}

--- a/packages/local-storage/spec/web/local_storage.spec.ts
+++ b/packages/local-storage/spec/web/local_storage.spec.ts
@@ -1,9 +1,18 @@
 /* global describe, it, expect */
 import { Loki } from "../../../loki/src/loki";
 import { LocalStorage } from "../../src/local_storage";
+import {
+  InMemoryLocalStorage,
+  AsyncInMemoryLocalStorage,
+} from "../fixtures/in-memory-local-storage";
+
+const STORAGES = {
+  "window.localStorage": window.localStorage,
+  InMemoryLocalStorage: new InMemoryLocalStorage(),
+  AsyncInMemoryLocalStorage: new AsyncInMemoryLocalStorage(),
+};
 
 describe("testing local storage", function () {
-
   interface Name {
     name: string;
   }
@@ -16,80 +25,63 @@ describe("testing local storage", function () {
     LocalStorage.deregister();
   });
 
-  it("LokiLocalStorage", function (done) {
-    const db = new Loki("myTestApp");
-    const adapter = {adapter: new LocalStorage()};
-    db.initializePersistence(adapter)
-      .then(() => {
-        db.addCollection<Name>("myColl").insert({name: "Hello World"});
-        return db.saveDatabase();
-      })
-      .then(() => {
+  for (const [storageName, storage] of Object.entries(STORAGES)) {
+    describe(`Testing with ${storageName}`, () => {
+      const adapter = new LocalStorage(storage);
+
+      it("should isolate different databases, collections and objects", async function () {
+        const db = new Loki("myTestApp");
+        await db.initializePersistence({ adapter });
+        db.addCollection<Name>("myColl").insert({ name: "Hello World" });
+        await db.saveDatabase();
+
         const db2 = new Loki("myTestApp");
-        return db2.initializePersistence()
-          .then(() => {
-            return db2.loadDatabase();
-          }).then(() => {
-            expect(db2.getCollection<Name>("myColl").find()[0].name).toEqual("Hello World");
-          });
-      })
-      .then(() => {
-        const db2 = new Loki("myTestApp");
-        return db2.initializePersistence({persistenceMethod: "local-storage"})
-          .then(() => {
-            return db2.loadDatabase();
-          }).then(() => {
-            expect(db2.getCollection<Name>("myColl").find()[0].name).toEqual("Hello World");
-          });
-      })
-      .then(() => {
+        await db2.initializePersistence({ adapter });
+        await db2.loadDatabase();
+        expect(db2.getCollection<Name>("myColl").find()[0].name).toEqual(
+          "Hello World"
+        );
+
+        await db2.initializePersistence({
+          persistenceMethod: "local-storage",
+          adapter,
+        });
+        await db2.loadDatabase();
+        expect(db2.getCollection<Name>("myColl").find()[0].name).toEqual(
+          "Hello World"
+        );
+
         const db3 = new Loki("other");
-        return db3.initializePersistence()
-          .then(() => {
-            return db3.loadDatabase();
-          }).then(() => {
-            expect(false).toEqual(true);
-          }, () => {
-            expect(true).toEqual(true);
-          });
-      })
-      .then(() => {
-        return db.deleteDatabase();
-      })
-      .then(() => {
-        return db.loadDatabase()
-          .then(() => {
-            expect(db.getCollection<Name>("myColl").find()[0].name).toEqual("Hello World");
-            expect(false).toEqual(true);
-            done();
-          }, () => {
-            expect(true).toEqual(true);
-            done();
-          });
+        await db3.initializePersistence({ adapter });
+        await expect(async () => {
+          await db3.loadDatabase();
+        }).not.toThrow();
+
+        await db.deleteDatabase();
+        await expect(async () => {
+          await db.loadDatabase();
+        }).not.toThrow();
       });
-  });
 
+      it("auto save and auto load", async function () {
+        const db = new Loki("myTestApp2");
 
-  it("auto save and auto load", function (done) {
-    const db = new Loki("myTestApp2");
+        await db.initializePersistence({
+          autosave: true,
+          autoload: true,
+          adapter,
+        });
 
-    db.initializePersistence({autosave: true, autoload: true})
-      .then(() => {
-        db.addCollection<Name>("myColl").insert({name: "Hello World"});
-        return db.close();
-      })
-      .then(() => {
+        db.addCollection<Name>("myColl").insert({ name: "Hello World" });
+        await db.close();
+
         const db2 = new Loki("myTestApp2");
-        return db2.initializePersistence({autosave: true, autoload: true})
-          .then(() => {
-            expect(db2.getCollection<Name>("myColl").find()[0].name).toEqual("Hello World");
-          });
-      })
-      .catch(e => {
-        fail(e);
-      })
-      .then(() => {
-        done();
+
+        await db2.initializePersistence({ autosave: true, autoload: true });
+        expect(db2.getCollection<Name>("myColl").find()[0].name).toEqual(
+          "Hello World"
+        );
       });
-  });
+    });
+  }
 });

--- a/packages/local-storage/src/index.ts
+++ b/packages/local-storage/src/index.ts
@@ -1,4 +1,5 @@
-import { LocalStorage } from "./local_storage";
+export * from "./types";
 
-export {LocalStorage};
+import { LocalStorage } from "./local_storage";
+export { LocalStorage };
 export default LocalStorage;

--- a/packages/local-storage/src/local_storage.ts
+++ b/packages/local-storage/src/local_storage.ts
@@ -1,11 +1,14 @@
 import { PLUGINS } from "../../common/plugin";
 import { StorageAdapter } from "../../common/types";
+import { Storage } from "./types";
 
 /**
  * A loki persistence adapter which persists to web browser's local storage object
  * @constructor LocalStorageAdapter
  */
 export class LocalStorage implements StorageAdapter {
+  private storage: Storage;
+
   /**
    * Registers the local storage as plugin.
    */
@@ -21,12 +24,19 @@ export class LocalStorage implements StorageAdapter {
   }
 
   /**
+   * @param {Storage} [constructor=window.localStorage] - Application name context can be used to distinguish subdomains, "loki" by default
+   */
+  constructor(storage: Storage = window.localStorage) {
+    this.storage = storage;
+  }
+
+  /**
    * loadDatabase() - Load data from localstorage
    * @param {string} dbname - the name of the database to load
    * @returns {Promise} a Promise that resolves after the database was loaded
    */
-  loadDatabase(dbname: string) {
-    return Promise.resolve(localStorage.getItem(dbname));
+  async loadDatabase(dbname: string) {
+    return this.storage.getItem(dbname);
   }
 
   /**
@@ -35,8 +45,8 @@ export class LocalStorage implements StorageAdapter {
    * @param {string} dbname - the filename of the database to load
    * @returns {Promise} a Promise that resolves after the database was saved
    */
-  saveDatabase(dbname: string, dbstring: string) {
-    return Promise.resolve(localStorage.setItem(dbname, dbstring));
+  async saveDatabase(dbname: string, dbstring: string) {
+    return this.storage.setItem(dbname, dbstring);
   }
 
   /**
@@ -45,8 +55,8 @@ export class LocalStorage implements StorageAdapter {
    * @param {string} dbname - the filename of the database to delete
    * @returns {Promise} a Promise that resolves after the database was deleted
    */
-  deleteDatabase(dbname: string) {
-    return Promise.resolve(localStorage.removeItem(dbname));
+  async deleteDatabase(dbname: string) {
+    return this.storage.removeItem(dbname);
   }
 }
 

--- a/packages/local-storage/src/types.ts
+++ b/packages/local-storage/src/types.ts
@@ -1,0 +1,10 @@
+export type SyncOrAsync<T> = T | Promise<T>;
+
+export interface Storage {
+  readonly length: number;
+  clear(): SyncOrAsync<void>;
+  getItem(key: string): SyncOrAsync<string | null>;
+  key(index: number): SyncOrAsync<string | null>;
+  removeItem(key: string): SyncOrAsync<void>;
+  setItem(key: string, value: string): SyncOrAsync<void>;
+}


### PR DESCRIPTION
The current implementation of the LocalStorage adapter relied directly on the browsers `window.localStorage`. These changes maintain the current behavior and allow devs to initialize the LocalStorage with a different `Storage` interface. I've defined the `Storage` interface to allow synchronous or asynchronous methods.

This change also allows LokiDB to persist information on platforms that don't offer indexedDB or FS. This is the case for React Native, or other implementations that don't support IndexedDB, by allowing devs to provide a storage interface, [React Native's Async Storage](https://reactnative.dev/docs/asyncstorage) can now be fed to LokiDB as a persistent storage mean.

Also took the chance that I had to edit the tests to ensure other implementations could fit into those interfaces, so I've introduced 2 mocked-storages, async and sync, to ensure the intended behavior works as expected. As the tests were not using the async/await feature, ended up rewriting those.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/LokiJS-Forge/LokiDB/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
